### PR TITLE
used default dict in api_v2/event instead of normal dict

### DIFF
--- a/4 - observer pattern/api_v2/event.py
+++ b/4 - observer pattern/api_v2/event.py
@@ -1,8 +1,9 @@
-subscribers = dict()
+from collections import defaultdict
+
+# Default value of the dictionary will be list
+subscribers = defaultdict(list)
 
 def subscribe(event_type: str, fn):
-    if not event_type in subscribers:
-        subscribers[event_type] = []
     subscribers[event_type].append(fn)
 
 def post_event(event_type: str, data):


### PR DESCRIPTION
### Defaultdict 

* The functionality of both dictionaries and defualtdict are almost same except for the fact that defualtdict never raises a KeyError.
* When key is not present it will return --> [] (empty list)

* This is how it improves the code
* **Before**
```
if event_type not in subscribers:
    subscribers[event_type] = []
subscribers[event_type].append(fn)
```

* **After**
```
subscribers[event_type].append(fn)
```