### PR TITLE
remove unnecessary import

### DIFF
--- a/3 - strategy pattern/strategy-after-fn.py
+++ b/3 - strategy pattern/strategy-after-fn.py
@@ -1,7 +1,6 @@
 import string
 import random
 from typing import List, Callable
-from abc import ABC, abstractmethod
 
 
 def generate_id(length=8):


### PR DESCRIPTION
Since it's functions only, importing from `abc`  is not needed.